### PR TITLE
corrected path in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Replace `example_shortname` with your Disqus shortname
 
 Fire up your terminal and run these commands before you start making changes:
 
-	cd /your-ghost-blog/content/themes
+	cd /your-ghost-blog/content/themes/journal
 	npm install
 	gulp
 


### PR DESCRIPTION
Small fix, development instructions in the README pointed users to `/your-ghost-blog/content/themes` instead of `/your-ghost-blog/content/themes/journal`
